### PR TITLE
Add option to pass props to WebView that renders the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Most props are based on the official parameters from [Typeform Embed SDK](https:
 | `opacity`     | Background opacity. Valid values include any integer between `0` (completely transparent) and `100` (completely opaque). Note that this isn't the same as the CSS opacity scale (0-1).<br />_Widget mode option_ | `100`     |
 | `buttonText`  | Text to display in the "Start" button. Displayed only on touch-screen and mobile devices.<br />_Widget mode option_                                                                                              | `"Start"` |
 | `onSubmit`    | **PRO accounts only**. Callback event that will execute immediately after a respondent successfully submits the typeform. <br />                                                                                 | N/A       |
+| `webView`     | Props passed to the WebView that displays the form                                                                                                                                                               | `{}`      |
 
 ### License
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class TypeformEmbed extends Component {
         }}
         onLoadEnd={this.onLoad}
         onMessage={this.onMessage}
+        {...this.props.webView}
       />
     );
   }
@@ -64,6 +65,7 @@ TypeformEmbed.propTypes = {
 // https://developer.typeform.com/embed/modes/
 TypeformEmbed.defaultProps = {
   style: {},
+  webView: {},
 
   // Widget options
   hideHeaders: false,


### PR DESCRIPTION
Adds the `webView` prop which accepts an object consisting of additional props that are passed to the `WebView` which renders the Typeform form.